### PR TITLE
fix: accept 'passed' as alias for 'pass' in FlickreviewR status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Deployed to Wikimedia Toolforge as containerized jobs. Build with `toolforge bui
 
 `{{FlickreviewR |status= |author= |sourceurl= |reviewdate= |reviewlicense= |reviewer= |archive= }}`
 
-The `status` parameter determines the review outcome. Only `pass` means the license is compatible. Other values: `fail`, `notmatching`, `error`, `nosource`, `notfound`, `pass-change`, `public-domain-mark`, `library-of-congress`, `powerhouse-museum`, `bad-author`.
+The `status` parameter determines the review outcome. Only `pass` means the license is compatible. The template supports aliases (see [[Template:FlickreviewR/status aliases]]) — `passed` is an alias for `pass`. Other values: `fail`/`failed`, `notmatching`, `error`, `nosource`, `notfound`, `pass-change`/`passed_changed`, `public-domain-mark`, `library-of-congress`, `powerhouse-museum`, `bad-author`.
 
 ### Constraints
 

--- a/src/wikibots/flickr.py
+++ b/src/wikibots/flickr.py
@@ -87,7 +87,7 @@ class FlickrBot(BaseBot):
 
         review_status = self.retrieve_template_data(["FlickreviewR"], ["status"])
         if review_status not in ("pass", "passed"):
-            warning(f"Skipping: FlickreviewR status is {review_status!r}, not 'pass'")
+            warning(f"Skipping: FlickreviewR status is {review_status!r}, not 'pass' or 'passed'")
             self.redis.set(self.wiki_properties.redis_key, 1)
             return None
 

--- a/src/wikibots/flickr.py
+++ b/src/wikibots/flickr.py
@@ -86,7 +86,7 @@ class FlickrBot(BaseBot):
         assert self.wiki_properties
 
         review_status = self.retrieve_template_data(["FlickreviewR"], ["status"])
-        if review_status != "pass":
+        if review_status not in ("pass", "passed"):
             warning(f"Skipping: FlickreviewR status is {review_status!r}, not 'pass'")
             self.redis.set(self.wiki_properties.redis_key, 1)
             return None


### PR DESCRIPTION
The FlickreviewR template supports status aliases (Template:FlickreviewR/status_aliases).
'passed' is a valid alias for 'pass', but the bot was incorrectly skipping files with this status.

Also updates CLAUDE.md to document the alias system.