### PR TITLE
fix: restore pywikibot config access through wrapper import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,4 @@ The `status` parameter determines the review outcome. Only `pass` means the lice
 ### Constraints
 
 - `redis` must stay on `<6.0.0` — Toolforge runs Redis server 6.0.16, and redis-py 7.x requires Redis 7.2+.
+- pywikibot config is accessed via `pwb.config` where `pwb` is imported from `pywikibot.scripts.wrapper`. Importing through the wrapper triggers proper pywikibot initialization — using `pywikibot.config` directly does not work. The ty `possibly-missing-submodule` warnings on `pwb.config` are expected (exit 0).

--- a/src/wikibots/lib/bot.py
+++ b/src/wikibots/lib/bot.py
@@ -9,7 +9,6 @@ from time import perf_counter
 from typing import Any
 
 import mwparserfromhell
-import pywikibot.config
 import requests
 from deepdiff import DeepDiff
 from mwparserfromhell.wikicode import Wikicode
@@ -28,6 +27,7 @@ from pywikibot.bot import ExistingPageBot
 from pywikibot.data.api import Request
 from pywikibot.page import BasePage
 from pywikibot.page._collections import ClaimCollection
+from pywikibot.scripts.wrapper import pwb
 from redis import Redis
 
 from wikibots.lib.wikidata import WikidataEntity, WikidataProperty
@@ -71,11 +71,11 @@ class BaseBot(ExistingPageBot):
                 _access_token,
                 _access_secret,
             )
-            pywikibot.config.authenticate["commons.wikimedia.org"] = authenticate
+            pwb.config.authenticate["commons.wikimedia.org"] = authenticate
         else:
-            pywikibot.config.password_file = "user-password.py"
+            pwb.config.password_file = "user-password.py"
 
-        pywikibot.config.put_throttle = self.throttle
+        pwb.config.put_throttle = self.throttle
 
         self.wikidata = Site("wikidata", "wikidata")
         self.commons = Site("commons", "commons", user=os.getenv("PWB_USERNAME"))


### PR DESCRIPTION
PR #77 replaced `pwb.config` (from `pywikibot.scripts.wrapper`) with `pywikibot.config` to fix type errors. However, the wrapper import is required for proper pywikibot initialization — without it, config settings (auth tokens, throttle) don't take effect.

This reverts the config access pattern to use `pwb.config` and documents the constraint in CLAUDE.md.