### PR TITLE
fix: check API error response and set Redis cache after successful save

### DIFF
--- a/src/wikibots/lib/bot.py
+++ b/src/wikibots/lib/bot.py
@@ -306,9 +306,16 @@ class BaseBot(ClaimsMixin):
                 timeout=60.0,
             )
             response.raise_for_status()
+            result = response.json()
+            if "error" in result:
+                logger.critical(
+                    f"API error saving {self.wiki_properties.mid}: {result['error']}"
+                )
+                return
             logger.info(
                 f"Updating {self.wiki_properties.mid} took {(perf_counter() - start):.1f} s"
             )
+            self.redis.set(self.wiki_properties.redis_key, 1)
             self.null_edit()
         except Exception as e:
             logger.critical(f"Failed to update: {e}")


### PR DESCRIPTION
Two bugs in `bot.py`'s `save()` method:

1. **API errors silently ignored**: `response.raise_for_status()` only catches HTTP-level errors (4xx/5xx). The MediaWiki API returns application errors as HTTP 200 with `{"error": {...}}` in the body. A failed save was indistinguishable from success.

2. **Redis key not set after successful save**: `self.redis.set()` was only called when there were no new claims. After a successful `wbeditentity` call, the Redis key was never set, causing the bot to re-process the same page on subsequent runs.