### PR TITLE
fix: handle missing canprint attribute in Flickr API usage element

### DIFF
--- a/src/wikibots/flickr.py
+++ b/src/wikibots/flickr.py
@@ -20,6 +20,17 @@ logger = logging.getLogger(__name__)
 RATE_LIMIT_DELAYS = (60, 180, 300)
 
 
+class _PatchedFlickrApi(FlickrApi):
+    # Temporary fix until flickr-photos-api handles missing <usage> attributes
+    def parse_single_photo_info(self, info_resp, *, photo_id):
+        usage_elem = info_resp.find("photo/usage")
+        if usage_elem is not None:
+            for attr in ("candownload", "canblog", "canprint", "canshare"):
+                if attr not in usage_elem.attrib:
+                    usage_elem.set(attr, "0")
+        return super().parse_single_photo_info(info_resp, photo_id=photo_id)
+
+
 class FlickrBot(BaseBot):
     redis_prefix = "xQ6cz5J84Viw/K6FIcOH1kxJjfiS8jO56AoSmhBgO/A="
     summary = "add [[Commons:Structured data|SDC]] based on metadata from Flickr"
@@ -32,7 +43,7 @@ class FlickrBot(BaseBot):
     def __init__(self) -> None:
         super().__init__()
 
-        self.flickr_api = FlickrApi.with_api_key(
+        self.flickr_api = _PatchedFlickrApi.with_api_key(
             api_key=os.getenv("FLICKR_API_KEY", ""),
             user_agent=self.user_agent,
         )

--- a/tests/test_flickr_rate_limit.py
+++ b/tests/test_flickr_rate_limit.py
@@ -4,7 +4,6 @@ from xml.etree import ElementTree as ET
 
 import httpx
 import pytest
-
 from flickr_api import FlickrApi
 
 from wikibots.flickr import FlickrBot, _PatchedFlickrApi

--- a/tests/test_flickr_rate_limit.py
+++ b/tests/test_flickr_rate_limit.py
@@ -13,7 +13,7 @@ def make_bot() -> FlickrBot:
     with (
         patch("wikibots.lib.bot.Redis") as mock_redis_cls,
         patch("wikibots.lib.bot.requests.Session"),
-        patch("wikibots.flickr.FlickrApi"),
+        patch("wikibots.flickr._PatchedFlickrApi"),
     ):
         mock_redis_cls.return_value.ping.return_value = True
         bot = FlickrBot()

--- a/tests/test_flickr_rate_limit.py
+++ b/tests/test_flickr_rate_limit.py
@@ -1,10 +1,13 @@
 from typing import cast
 from unittest.mock import MagicMock, call, patch
+from xml.etree import ElementTree as ET
 
 import httpx
 import pytest
 
-from wikibots.flickr import FlickrBot
+from flickr_api import FlickrApi
+
+from wikibots.flickr import FlickrBot, _PatchedFlickrApi
 from wikibots.lib.bot import RateLimitExhausted
 
 
@@ -27,6 +30,35 @@ def make_429_error() -> httpx.HTTPStatusError:
     return httpx.HTTPStatusError(
         "429 Too Many Requests", request=MagicMock(), response=response
     )
+
+
+def test_patched_flickr_api_fills_missing_usage_attrs():
+    info_resp = ET.fromstring(
+        '<rsp><photo><usage candownload="1" canblog="0" canshare="1"/></photo></rsp>'
+    )
+    with patch.object(FlickrApi, "parse_single_photo_info", return_value={}):
+        api = _PatchedFlickrApi.__new__(_PatchedFlickrApi)
+        api.parse_single_photo_info(info_resp, photo_id="55315578212")
+
+    usage = info_resp.find("photo/usage")
+    assert usage is not None
+    assert usage.attrib["canprint"] == "0"
+    assert usage.attrib["candownload"] == "1"
+    assert usage.attrib["canblog"] == "0"
+    assert usage.attrib["canshare"] == "1"
+
+
+def test_patched_flickr_api_does_not_overwrite_existing_usage_attrs():
+    info_resp = ET.fromstring(
+        '<rsp><photo><usage candownload="1" canblog="1" canprint="1" canshare="1"/></photo></rsp>'
+    )
+    with patch.object(FlickrApi, "parse_single_photo_info", return_value={}):
+        api = _PatchedFlickrApi.__new__(_PatchedFlickrApi)
+        api.parse_single_photo_info(info_resp, photo_id="12345")
+
+    usage = info_resp.find("photo/usage")
+    assert usage is not None
+    assert usage.attrib["canprint"] == "1"
 
 
 def test_rate_limit_retries_with_delays_then_raises(mocker):


### PR DESCRIPTION
## Problem

Some Flickr photos return a `<usage>` element without the `canprint` attribute (and potentially other attributes like `candownload`, `canblog`, `canshare`). The `flickr-photos-api` library (v3.12.1) does a hard dict access `usage_elem.attrib["canprint"]` with no fallback, raising `KeyError: 'canprint'`. This was caught by the broad `except Exception` in `get_flickr_photo` and logged as:

```
ERROR [55315578212] 'canprint'
```

The result was that affected photos only received a bare Flickr photo ID claim, losing all richer metadata (creator, source, date, location).

The `<usage>` element is undocumented in the official Flickr API spec — the library added support for it in v3.4 (May 2025) assuming all attributes are always present. A similar fix was applied upstream for `KeyError: 'realname'` in v3.8.1.

## Fix

Subclass `FlickrApi` as `_PatchedFlickrApi` and override `parse_single_photo_info` to fill in missing `<usage>` attributes with a default of `"0"` (conservative: cannot print/download/blog/share) before delegating to `super()`. This follows Python best practice of subclassing over direct method replacement.

The patch is scoped entirely to `FlickrBot` and is trivially removable once `flickr-photos-api` ships the upstream fix.